### PR TITLE
Extending errors handling in `validation_err.dart`

### DIFF
--- a/lib/src/exceptions/validation_err.dart
+++ b/lib/src/exceptions/validation_err.dart
@@ -13,13 +13,30 @@ class LValidationException extends LaravelException {
   /// contains the failed input keys in the exception object
   List<String> get keys => _errors.keys.toList();
 
-  String get firstErrorKey => keys.first;
+  List<String> errors() {
+    List<List<String>> errorsList = _errors.values.cast<List<String>>().toList();
+    errorsList.removeWhere((element) => element.isEmpty);
+    List<String> errors = [];
+    for (List<String> element in errorsList) {
+      if (element.length == 1) {
+        errors.add(element.first);
+        continue;
+      }
 
-  String? get firstErrorMessage => errorsByKey(firstErrorKey)?.first;
+      errors.add(element.join("\n"));
+    }
+    return errors;
+  }
+
+  String get firstErrorKey => keys.first;
 
   List<String> get firstErrorMessages => errorsByKey(firstErrorKey)!;
 
   List<String>? errorsByKey(String key) => _errors[key]?.cast<String>();
+
+  String? errorsCombinedByKey(String key) => _errors[key]?.cast<String>().join("\n");
+
+  String get errorsCombined => errors().join("\n");
 
   @override
   List<Object?> get props => [
@@ -49,8 +66,7 @@ class LValidationException extends LaravelException {
         final isLastMsg = i == _errors.keys.length;
 
         /// append the message
-        errorBuffer
-            .write('$currentFelid $currentMessage${isLastMsg ? '\n' : ''}');
+        errorBuffer.write('$currentFelid $currentMessage${isLastMsg ? '\n' : ''}');
       }
 
       /// append the message

--- a/test/laravel_validation_test.dart
+++ b/test/laravel_validation_test.dart
@@ -9,6 +9,7 @@ const resData = <String, dynamic>{
     ],
     'calling_code': [
       'The calling code may not be greater than 4 characters.',
+      'The dial code is invalid.',
     ],
     'mobile': [
       'The mobile may not be greater than 9 characters.',
@@ -30,8 +31,13 @@ void main() async {
         equals('website'),
       );
       expect(
-        exception.firstErrorMessage,
-        equals('The website format is invalid.'),
+        exception.errorsCombined,
+        equals(
+          """The website format is invalid.\n"""
+          """The calling code may not be greater than 4 characters.\n"""
+          """The dial code is invalid.\n"""
+          """The mobile may not be greater than 9 characters.""",
+        ),
       );
       expect(
         exception.message,
@@ -44,6 +50,21 @@ void main() async {
       expect(
         exception.firstErrorMessages,
         equals(['The website format is invalid.']),
+      );
+
+      expect(
+        exception.errorsCombinedByKey("calling_code"),
+        equals(
+          """The calling code may not be greater than 4 characters.\n"""
+          """The dial code is invalid.""",
+        ),
+      );
+
+      expect(
+        exception.errors().length,
+        equals(
+          exception.keys.length,
+        ),
       );
 
       expect(


### PR DESCRIPTION
I've been facing issues using this package and specifically `LValidationError` class if I want to display all the errors returned, So I added a couple of methods to help with it :")